### PR TITLE
Add yaml config file support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -108,3 +108,7 @@ Assistant: The capital of France is Paris."""
 ```
 
 This keeps responses aligned with expected behavior and improves reliability across different files.
+
+### Server YAML config
+
+See `docs/server_config.md` and `docs/server_config_example.yaml` for configuring the server via a single YAML file and running with `--config`.

--- a/docs/server_config.md
+++ b/docs/server_config.md
@@ -1,0 +1,39 @@
+### YAML configuration for sglang.launch_server
+
+- Run with a single YAML file:
+
+```bash
+python3 -m sglang.launch_server --config config.yaml
+```
+
+- CLI overrides YAML. You can still pass flags alongside `--config` and they win:
+
+```bash
+python3 -m sglang.launch_server --config config.yaml --port 31000 --log-level debug
+```
+
+- You can also set `SGLANG_CONFIG=/path/to/config.yaml` to use a config by default.
+
+- Supported keys: All existing server flags. Use either the long flag name with dashes (e.g., `model-path`) or the Python-style name with underscores (e.g., `model_path`). Short aliases are supported for parallel sizes: `tp`, `pp`, `dp`, `ep`.
+
+- Example file: see `docs/server_config_example.yaml`.
+
+### YAML for router+server launcher
+
+For the combined launcher `sgl-router/py_src/sglang_router/launch_server.py`, provide a single YAML with two sections:
+
+```yaml
+server:
+  model: meta-llama/Meta-Llama-3-8B-Instruct
+  tp: 2
+  host: 0.0.0.0
+  port: 30000
+
+router:
+  worker-urls:
+    - http://127.0.0.1:31001
+    - http://127.0.0.1:31002
+  policy: cache_aware
+```
+
+CLI flags still override YAML values.

--- a/docs/server_config_example.yaml
+++ b/docs/server_config_example.yaml
@@ -1,0 +1,44 @@
+# Example SGLang server configuration
+# Save as config.yaml and run:
+#   python3 -m sglang.launch_server --config config.yaml
+
+# Model settings
+model: meta-llama/Meta-Llama-3-8B-Instruct
+revision: null
+trust-remote-code: true
+
+# Parallelism
+# You can use short aliases tp/pp/dp/ep or full names
+# tp maps to --tensor-parallel-size, etc.
+tp: 2
+pp: 1
+dp: 1
+ep: 1
+
+# HTTP server
+host: 0.0.0.0
+port: 30000
+api-key: null
+
+# Memory and scheduling
+mem-fraction-static: 0.88
+max-prefill-tokens: 16384
+schedule-policy: fcfs
+
+# Quantization and dtypes
+dtype: auto
+quantization: null
+kv-cache-dtype: auto
+
+# Logging
+log-level: info
+log-level-http: warning
+log-requests: false
+
+# Example of nested structure also supported by router launcher
+# router:
+#   worker-urls:
+#     - http://127.0.0.1:31001
+#     - http://127.0.0.1:31002
+#   policy: cache_aware
+#   prometheus-port: 29000


### PR DESCRIPTION
## Motivation

This PR introduces support for loading server and router configuration from a single YAML file via a `--config` argument or `SGLANG_CONFIG` environment variable. This aims to improve deployment flexibility, reproducibility, and align with best practices for configuration management by centralizing all settings (including multi-node, TP/DP/EP, GPU options) in one file, rather than relying solely on CLI arguments.

## Modifications

- Added `--config <path>` argument to `sglang.launch_server` and `sgl-router/py_src/sglang_router/launch_server.py`.
- Implemented YAML parsing and merging logic:
    - CLI arguments take precedence over YAML values.
    - Supports `SGLANG_CONFIG` environment variable for default config path.
    - Normalizes YAML keys (e.g., `model-path` or `model_path`) and includes common aliases (e.g., `tp` for `tensor_parallel_size`).
    - Serializes complex YAML structures (dictionaries/lists) into JSON strings for specific arguments (e.g., `json_model_override_args`).
    - For the combined router+server launcher, supports top-level `server:` and `router:` sections within the YAML file.
- Added documentation: `docs/server_config.md` and `docs/server_config_example.yaml`, linked from `docs/README.md`.
- Added `pyyaml` as an optional dependency.

## Accuracy Test

N/A. This PR focuses on configuration parsing and does not affect model-side code or inference accuracy.

## Benchmark & Profiling

N/A. This PR introduces a configuration loading mechanism and is not expected to impact runtime performance.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

---
<a href="https://cursor.com/background-agent?bcId=bc-9047a8b1-3620-458a-97fc-7e8d1679023e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9047a8b1-3620-458a-97fc-7e8d1679023e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

