### PR TITLE
Investigate host 0.0.0.0 access denied error

### DIFF
--- a/PROXY_ISSUE_SOLUTION.md
+++ b/PROXY_ISSUE_SOLUTION.md
@@ -1,0 +1,155 @@
+# SGLang Server Proxy Issue with --host 0.0.0.0
+
+## 问题描述
+
+当使用 `--host 0.0.0.0` 启动 SGLang 服务器时，会出现以下错误：
+
+```
+[2025-08-13 11:03:03] Initialization failed. warmup error: 
+AssertionError: res=<Response [403]>, res.text='<!DOCTYPE html...ERROR: The requested URL could not be retrieved...Access Denied...'
+```
+
+服务器本身启动成功，但在 warmup（预热）阶段失败，收到来自 Squid 代理服务器（172.16.37.200:3138）的 403 Access Denied 错误。
+
+## 根本原因分析
+
+### 问题流程
+1. SGLang 服务器使用 `--host 0.0.0.0` 参数启动，监听所有网络接口
+2. 服务器启动后，执行 `_execute_server_warmup()` 函数进行预热
+3. 预热函数直接使用 `--host` 参数构建 URL：`http://0.0.0.0:25600/get_model_info`
+4. Python 的 requests 库发送请求到 `0.0.0.0` 地址
+5. 系统配置的 HTTP 代理（Squid）拦截了这个请求
+6. 企业代理出于安全考虑，禁止访问 `0.0.0.0` 地址，返回 403 错误
+
+### 为什么 127.0.0.1 能正常工作？
+- `127.0.0.1` 是本地回环地址
+- 大多数代理配置会自动跳过 localhost 地址
+- 请求直接到达本地服务，不经过代理
+
+## 解决方案
+
+### 方案 1：设置环境变量跳过代理（推荐）
+
+最简单的解决方案是设置 `NO_PROXY` 环境变量：
+
+```bash
+# 方式 1：导出环境变量
+export NO_PROXY=0.0.0.0,localhost,127.0.0.1
+export no_proxy=0.0.0.0,localhost,127.0.0.1
+
+# 方式 2：在命令前添加环境变量
+NO_PROXY=0.0.0.0,localhost,127.0.0.1 \
+no_proxy=0.0.0.0,localhost,127.0.0.1 \
+$PYTHONHOME/bin/python3 -m sglang.launch_server \
+    --model-path $MODEL_PATH \
+    --host 0.0.0.0 \
+    --port 3000 \
+    --disable-cuda-graph \
+    --trust-remote-code \
+    --context-length 40960 \
+    --tp 8 \
+    --watchdog-timeout 600 \
+    --log-level debug \
+    2>&1 >> $SCRIPT_DIR/sglang.log &
+```
+
+### 方案 2：修改 SGLang 源代码（永久修复）
+
+已经应用的补丁修改了 `/workspace/python/sglang/srt/entrypoints/http_server.py` 文件：
+
+```python
+def _execute_server_warmup(
+    server_args: ServerArgs,
+    pipe_finish_writer: Optional[multiprocessing.connection.Connection],
+):
+    headers = {}
+    # Use localhost for warmup when binding to 0.0.0.0 to avoid proxy issues
+    if server_args.host == "0.0.0.0":
+        url = f"http://127.0.0.1:{server_args.port}"
+    else:
+        url = server_args.url()
+    if server_args.api_key:
+        headers["Authorization"] = f"Bearer {server_args.api_key}"
+```
+
+这个修改确保即使服务器绑定到 `0.0.0.0`，预热请求也会使用 `127.0.0.1` 以避免代理问题。
+
+### 方案 3：使用包装脚本
+
+创建了 `/workspace/sglang_server_wrapper.sh` 脚本，自动处理代理设置：
+
+```bash
+#!/bin/bash
+# 使用包装脚本启动服务器
+/workspace/sglang_server_wrapper.sh \
+    --model-path $MODEL_PATH \
+    --host 0.0.0.0 \
+    --port 3000 \
+    --disable-cuda-graph \
+    --trust-remote-code \
+    --context-length 40960 \
+    --tp 8 \
+    --watchdog-timeout 600 \
+    --log-level debug \
+    2>&1 >> $SCRIPT_DIR/sglang.log &
+```
+
+### 方案 4：跳过预热（不推荐）
+
+添加 `--skip-server-warmup` 参数：
+
+```bash
+$PYTHONHOME/bin/python3 -m sglang.launch_server \
+    --model-path $MODEL_PATH \
+    --host 0.0.0.0 \
+    --port 3000 \
+    --skip-server-warmup \  # 添加此参数
+    --disable-cuda-graph \
+    --trust-remote-code \
+    --context-length 40960 \
+    --tp 8 \
+    --watchdog-timeout 600 \
+    --log-level debug \
+    2>&1 >> $SCRIPT_DIR/sglang.log &
+```
+
+**注意**：跳过预热可能会影响服务器的初始性能。
+
+### 方案 5：使用具体 IP 地址
+
+使用容器的实际 IP 地址而不是 `0.0.0.0`：
+
+```bash
+# 获取容器 IP
+CONTAINER_IP=$(hostname -I | awk '{print $1}')
+
+# 使用具体 IP 启动
+$PYTHONHOME/bin/python3 -m sglang.launch_server \
+    --model-path $MODEL_PATH \
+    --host $CONTAINER_IP \
+    --port 3000 \
+    # ... 其他参数
+```
+
+## 已创建的文件
+
+1. **`/workspace/fix_proxy_issue.py`** - 分析脚本，提供详细的问题分析和解决方案
+2. **`/workspace/sglang_warmup_fix.patch`** - 源代码补丁文件
+3. **`/workspace/sglang_server_wrapper.sh`** - 自动设置环境变量的包装脚本
+4. **源代码已修改** - `python/sglang/srt/entrypoints/http_server.py` 已应用修复
+
+## 建议
+
+1. **短期解决**：使用方案 1（环境变量）或方案 3（包装脚本）
+2. **长期解决**：源代码已修改（方案 2），下次重启后生效
+3. **最佳实践**：在 Docker 容器中，建议在 Dockerfile 或启动脚本中设置 `NO_PROXY` 环境变量
+
+## 验证修复
+
+修复后，服务器应该能够成功完成预热并正常启动：
+
+```
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://0.0.0.0:25600
+# 不再出现 403 错误
+```

--- a/fix_proxy_issue.py
+++ b/fix_proxy_issue.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""
+Fix for SGLang server proxy issue when using --host 0.0.0.0
+
+Problem Analysis:
+When using --host 0.0.0.0, the warmup request is being intercepted by a Squid proxy 
+(172.16.37.200:3138) which blocks access to 0.0.0.0:25600 with a 403 Access Denied error.
+
+Root Cause:
+The warmup code in _execute_server_warmup() uses the host parameter directly to construct 
+the URL (http://0.0.0.0:25600/get_model_info). When Python's requests library sees 0.0.0.0,
+it may route through the system proxy, which blocks access to 0.0.0.0 addresses for security.
+"""
+
+import os
+import sys
+import subprocess
+import json
+
+def print_analysis():
+    """Print detailed analysis of the issue"""
+    print("=" * 80)
+    print("SGLANG SERVER PROXY ISSUE ANALYSIS")
+    print("=" * 80)
+    print()
+    print("PROBLEM:")
+    print("  When starting SGLang server with --host 0.0.0.0, the warmup fails with:")
+    print("  - 403 Access Denied from Squid proxy (172.16.37.200:3138)")
+    print("  - Server starts successfully but warmup requests are blocked")
+    print()
+    print("ROOT CAUSE:")
+    print("  1. SGLang's warmup code constructs URL using the --host parameter directly")
+    print("  2. When --host is 0.0.0.0, warmup tries to connect to http://0.0.0.0:port")
+    print("  3. Python requests library routes 0.0.0.0 through system proxy")
+    print("  4. Corporate proxy (Squid) blocks access to 0.0.0.0 for security reasons")
+    print()
+    print("WHY IT WORKS WITH 127.0.0.1:")
+    print("  - Localhost addresses (127.0.0.1) bypass proxy settings")
+    print("  - Direct connection without proxy interference")
+    print()
+
+def provide_solutions():
+    """Provide multiple solutions for the issue"""
+    print("=" * 80)
+    print("SOLUTIONS")
+    print("=" * 80)
+    print()
+    
+    print("SOLUTION 1: Disable proxy for SGLang process (RECOMMENDED)")
+    print("-" * 40)
+    print("Add these environment variables before starting SGLang:")
+    print()
+    print("export NO_PROXY=0.0.0.0,localhost,127.0.0.1")
+    print("export no_proxy=0.0.0.0,localhost,127.0.0.1")
+    print()
+    print("Or in your startup script:")
+    print()
+    print("""NO_PROXY=0.0.0.0,localhost,127.0.0.1 \\
+no_proxy=0.0.0.0,localhost,127.0.0.1 \\
+$PYTHONHOME/bin/python3 -m sglang.launch_server \\
+    --model-path $MODEL_PATH \\
+    --host 0.0.0.0 \\
+    --port 3000 \\
+    --disable-cuda-graph \\
+    --trust-remote-code \\
+    --context-length 40960 \\
+    --tp 8 \\
+    --watchdog-timeout 600 \\
+    --log-level debug \\
+    2>&1 >> $SCRIPT_DIR/sglang.log &""")
+    print()
+    
+    print("SOLUTION 2: Patch SGLang warmup code")
+    print("-" * 40)
+    print("Modify the warmup to use localhost for internal checks:")
+    print("File: python/sglang/srt/entrypoints/http_server.py")
+    print()
+    print("Change line 1294 from:")
+    print('    url = server_args.url()')
+    print("To:")
+    print('    # Use localhost for warmup even when binding to 0.0.0.0')
+    print('    if server_args.host == "0.0.0.0":')
+    print('        url = f"http://127.0.0.1:{server_args.port}"')
+    print('    else:')
+    print('        url = server_args.url()')
+    print()
+    
+    print("SOLUTION 3: Skip server warmup")
+    print("-" * 40)
+    print("Add --skip-server-warmup flag (less recommended):")
+    print()
+    print("""$PYTHONHOME/bin/python3 -m sglang.launch_server \\
+    --model-path $MODEL_PATH \\
+    --host 0.0.0.0 \\
+    --port 3000 \\
+    --skip-server-warmup \\  # Add this flag
+    --disable-cuda-graph \\
+    --trust-remote-code \\
+    --context-length 40960 \\
+    --tp 8 \\
+    --watchdog-timeout 600 \\
+    --log-level debug \\
+    2>&1 >> $SCRIPT_DIR/sglang.log &""")
+    print()
+    print("Note: Skipping warmup may affect initial performance")
+    print()
+    
+    print("SOLUTION 4: Use specific IP address")
+    print("-" * 40)
+    print("Instead of 0.0.0.0, use your container's actual IP:")
+    print()
+    print("# Get container IP")
+    print("hostname -I | awk '{print $1}'")
+    print()
+    print("# Use it in --host parameter")
+    print("--host <your-container-ip>")
+    print()
+
+def create_patch_file():
+    """Create a patch file for the warmup fix"""
+    patch_content = """--- a/python/sglang/srt/entrypoints/http_server.py
++++ b/python/sglang/srt/entrypoints/http_server.py
+@@ -1291,7 +1291,12 @@ def _execute_server_warmup(
+     pipe_finish_writer: Optional[multiprocessing.connection.Connection],
+ ):
+     headers = {}
+-    url = server_args.url()
++    # Use localhost for warmup when binding to 0.0.0.0 to avoid proxy issues
++    if server_args.host == "0.0.0.0":
++        url = f"http://127.0.0.1:{server_args.port}"
++    else:
++        url = server_args.url()
++    
+     if server_args.api_key:
+         headers["Authorization"] = f"Bearer {server_args.api_key}"
+"""
+    
+    with open("/workspace/sglang_warmup_fix.patch", "w") as f:
+        f.write(patch_content)
+    
+    print("PATCH FILE CREATED: /workspace/sglang_warmup_fix.patch")
+    print("-" * 40)
+    print("To apply the patch:")
+    print("cd /workspace && patch -p1 < sglang_warmup_fix.patch")
+    print()
+
+def create_wrapper_script():
+    """Create a wrapper script that handles the proxy issue automatically"""
+    wrapper_content = """#!/bin/bash
+# SGLang server wrapper script with proxy fix
+
+# Disable proxy for local addresses
+export NO_PROXY="0.0.0.0,localhost,127.0.0.1,*.local"
+export no_proxy="0.0.0.0,localhost,127.0.0.1,*.local"
+
+# Also unset proxy variables if needed (uncomment if required)
+# unset HTTP_PROXY
+# unset HTTPS_PROXY
+# unset http_proxy
+# unset https_proxy
+
+echo "Starting SGLang server with proxy bypass..."
+echo "NO_PROXY=$NO_PROXY"
+
+# Pass all arguments to sglang
+exec $PYTHONHOME/bin/python3 -m sglang.launch_server "$@"
+"""
+    
+    with open("/workspace/sglang_server_wrapper.sh", "w") as f:
+        f.write(wrapper_content)
+    
+    os.chmod("/workspace/sglang_server_wrapper.sh", 0o755)
+    
+    print("WRAPPER SCRIPT CREATED: /workspace/sglang_server_wrapper.sh")
+    print("-" * 40)
+    print("Usage:")
+    print("""/workspace/sglang_server_wrapper.sh \\
+    --model-path $MODEL_PATH \\
+    --host 0.0.0.0 \\
+    --port 3000 \\
+    --disable-cuda-graph \\
+    --trust-remote-code \\
+    --context-length 40960 \\
+    --tp 8 \\
+    --watchdog-timeout 600 \\
+    --log-level debug \\
+    2>&1 >> $SCRIPT_DIR/sglang.log &""")
+    print()
+
+def main():
+    print_analysis()
+    provide_solutions()
+    print("=" * 80)
+    print("CREATING FIX FILES")
+    print("=" * 80)
+    print()
+    create_patch_file()
+    create_wrapper_script()
+    
+    print("=" * 80)
+    print("IMMEDIATE WORKAROUND")
+    print("=" * 80)
+    print()
+    print("For immediate use without modifying code, run:")
+    print()
+    print("NO_PROXY=0.0.0.0,localhost,127.0.0.1 \\")
+    print("no_proxy=0.0.0.0,localhost,127.0.0.1 \\")
+    print("  <your original sglang command>")
+    print()
+    print("This will bypass the proxy for local addresses.")
+    print()
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1291,7 +1291,11 @@ def _execute_server_warmup(
     pipe_finish_writer: Optional[multiprocessing.connection.Connection],
 ):
     headers = {}
-    url = server_args.url()
+    # Use localhost for warmup when binding to 0.0.0.0 to avoid proxy issues
+    if server_args.host == "0.0.0.0":
+        url = f"http://127.0.0.1:{server_args.port}"
+    else:
+        url = server_args.url()
     if server_args.api_key:
         headers["Authorization"] = f"Bearer {server_args.api_key}"
 

--- a/sglang_server_wrapper.sh
+++ b/sglang_server_wrapper.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# SGLang server wrapper script with proxy fix
+
+# Disable proxy for local addresses
+export NO_PROXY="0.0.0.0,localhost,127.0.0.1,*.local"
+export no_proxy="0.0.0.0,localhost,127.0.0.1,*.local"
+
+# Also unset proxy variables if needed (uncomment if required)
+# unset HTTP_PROXY
+# unset HTTPS_PROXY
+# unset http_proxy
+# unset https_proxy
+
+echo "Starting SGLang server with proxy bypass..."
+echo "NO_PROXY=$NO_PROXY"
+
+# Pass all arguments to sglang
+exec $PYTHONHOME/bin/python3 -m sglang.launch_server "$@"

--- a/sglang_warmup_fix.patch
+++ b/sglang_warmup_fix.patch
@@ -1,0 +1,15 @@
+--- a/python/sglang/srt/entrypoints/http_server.py
++++ b/python/sglang/srt/entrypoints/http_server.py
+@@ -1291,7 +1291,12 @@ def _execute_server_warmup(
+     pipe_finish_writer: Optional[multiprocessing.connection.Connection],
+ ):
+     headers = {}
+-    url = server_args.url()
++    # Use localhost for warmup when binding to 0.0.0.0 to avoid proxy issues
++    if server_args.host == "0.0.0.0":
++        url = f"http://127.0.0.1:{server_args.port}"
++    else:
++        url = server_args.url()
++    
+     if server_args.api_key:
+         headers["Authorization"] = f"Bearer {server_args.api_key}"


### PR DESCRIPTION
## Motivation

This PR addresses a `403 Access Denied` error encountered during server warmup when the SGLang server is launched with `--host 0.0.0.0` in environments with corporate proxies. The issue arises because internal warmup requests to `0.0.0.0` are intercepted and blocked by the proxy.

## Modifications

The server warmup logic in `python/sglang/srt/entrypoints/http_server.py` has been updated. When the server is configured to listen on `0.0.0.0`, the internal warmup request to `/get_model_info` will now target `127.0.0.1` instead of `0.0.0.0`. This ensures the warmup request bypasses external proxy configurations that might block access to `0.0.0.0`.

## Accuracy Test

N/A (This PR addresses a server startup/networking issue, not model-side code.)

## Benchmark & Profiling

N/A (This PR addresses a server startup issue and is not expected to impact runtime performance.)

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

---
<a href="https://cursor.com/background-agent?bcId=bc-2601458e-2e78-445a-9ba3-4444ce72beb3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2601458e-2e78-445a-9ba3-4444ce72beb3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

